### PR TITLE
add connection timeout

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -147,7 +147,7 @@ class BasePlugin:
 
     def readMeter(self):
         try:
-            APIdata = urllib.request.urlopen("http://" + Parameters["Address"] + ":" + Parameters["Port"] + "/api/v1/data").read()
+            APIdata = urllib.request.urlopen("http://" + Parameters["Address"] + ":" + Parameters["Port"] + "/api/v1/data", timeout=self.pluginInterval/2).read()
         except:
             Domoticz.Error("Failed to communicate with Wi-Fi Watermeter at ip " + Parameters["Address"] + " with port " + Parameters["Port"])
             return False


### PR DESCRIPTION
Domoticz was reporting the watermeter worker thread is blocked.  By using a timeout parameter to `urllib.request.urlopen` no blocking call is made anymore. Once the meter is back in the wifi network subsequent calls will eventually succeed and the meter continues reporting again.